### PR TITLE
doc: document use of the Squash and merge button

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -302,16 +302,10 @@ The CTC should serve as the final arbiter where required.
 
 ## Landing Pull Requests
 
-* Please never use GitHub's green ["Merge Pull Request"](https://help.github.com/articles/merging-a-pull-request/#merging-a-pull-request-using-the-github-web-interface) button.
-  * If you do, please force-push removing the merge.
-  * Reasons for not using the web interface button:
-    * The merge method will add an unnecessary merge commit.
-    * The rebase & merge method adds metadata to the commit title.
-    * The rebase method changes the author.
-    * The squash & merge method has been known to add metadata to the
-    commit title.
-    * If more than one author has contributed to the PR, only the
-    latest author will be considered during the squashing.
+If the Pull Request can be landed as a single commit, you can use GitHub's green ["Squash and merge"](https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits) button, as long as you:
+ * Remove the PR number, e.g. `(#1048)`, from the commit message title.
+ * Make sure CI was run on the latest update to the Pull Request.
+ * Add the correct metadata (see below).
 
 Always modify the original commit message to include additional meta
 information regarding the change process:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Node.js
-
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/nodejs/node?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/29/badge)](https://bestpractices.coreinfrastructure.org/projects/29)
 
 Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine. Node.js


### PR DESCRIPTION
The `Create a Merge Commit` and `Rebase and Merge` buttons are not
currently suitable for merging Pull Requests, and are thus disabled.
Squashing is okay, so we should document its use.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
